### PR TITLE
Release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## v0.1.7 - 2025-01-28
+### Added
+#### UM Futures
+- `GET /fapi/v2/positionRisk` - This endpoint will soon be deprecated. Please use `GET /fapi/v3/positionRisk` instead.
+
 ## v0.1.6 - 2024-12-04
 ### Added
 #### UM Futures

--- a/README.md
+++ b/README.md
@@ -232,9 +232,10 @@ There are 2 types of error that may be returned from the API server and the user
 
 The WebSocket URLs for the available futures environments are as follows:
 
-- Testnet: wss://stream.binancefuture.com
-- Main CM: wss://dstream.binancefuture.com
-- Main UM: wss://fstream.binancefuture.com
+- Testnet CM: wss://dstream.binancefuture.com
+- Testnet UM: wss://stream.binancefuture.com
+- Main CM: wss://dstream.binance.com
+- Main UM: wss://fstream.binance.com
 
 ### Websocket Streams
 
@@ -255,7 +256,7 @@ const callbacks = {
 const umWebsocketStreamClient = new UMStream({
   logger,
   callbacks,
-  wsURL: "wss://fstream.binancefuture.com",
+  wsURL: "wss://fstream.binance.com",
 });
 
 // Subscribe to the allMarketMiniTickersStream stream

--- a/__tests__/um/account/getPositionInformationV2.test.js
+++ b/__tests__/um/account/getPositionInformationV2.test.js
@@ -1,0 +1,13 @@
+const { nockMock, UMFuturesClient } = require('../../testUtils/testSetup')
+const { mockResponse } = require('../../testUtils/mockData')
+
+describe('#getPositionInformationV2', () => {
+  it('should get position information v2', () => {
+    nockMock(UMFuturesClient.baseURL)('/fapi/v2/positionRisk')(mockResponse)
+
+    return UMFuturesClient.getPositionInformationV2().then((response) => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
+    })
+  })
+})

--- a/examples/um_futures/account/getPositionInformationV2.js
+++ b/examples/um_futures/account/getPositionInformationV2.js
@@ -1,0 +1,12 @@
+const { UMFutures } = require('../../../src')
+
+const apiKey = ''
+const apiSecret = ''
+const umFuturesClient = new UMFutures(apiKey, apiSecret, {
+  baseURL: 'https://fapi.binance.com'
+})
+
+umFuturesClient
+  .getPositionInformationV2()
+  .then((response) => console.log(response))
+  .catch(console.error)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@binance/futures-connector",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@binance/futures-connector",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@binance/futures-connector",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "NodeJS Binance Futures Connector",
   "main": "src/index.js",
   "scripts": {

--- a/src/modules/restful/um/account.js
+++ b/src/modules/restful/um/account.js
@@ -196,6 +196,25 @@ const Account = (superclass) =>
     }
 
     /**
+     * Position Information V2 (USER_DATA)
+     *
+     * GET /fapi/v3/positionRisk
+     *
+     * {@link https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/rest-api/Position-Information-V2}
+     *
+     * @param {object} [options]
+     * @param {string} [options.symbol]
+     * @param {number} [options.recvWindow]
+     */
+    getPositionInformationV2 (options = {}) {
+      return this.signRequest(
+        'GET',
+        `${this.baseURL}/${this.product}/v2/positionRisk`,
+        options
+      )
+    }
+
+    /**
      * Position Information V3 (USER_DATA)
      *
      * GET /fapi/v3/positionRisk

--- a/src/modules/websocket/UMStream.js
+++ b/src/modules/websocket/UMStream.js
@@ -6,7 +6,7 @@ const { isEmptyValue } = require('../../helpers/utils')
 class UMStream extends FuturesBaseStream {
   constructor (options = {}) {
     super(options)
-    this.wsURL = options.wsURL || 'wss://fstream.binancefuture.com'
+    this.wsURL = options.wsURL || 'wss://fstream.binance.com'
   }
 
   /**


### PR DESCRIPTION
### Added
#### UM Futures
- `GET /fapi/v2/positionRisk` - This endpoint will soon be deprecated. Please use `GET /fapi/v3/positionRisk` instead.